### PR TITLE
add com.unity.modules.jsonserialize to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
     "displayName": "Epic Online Services Plugin for Unity",
     "description": "Friendly Plugin for Epic Online Services",
     "documentationUrl": "https://eospluginforunity.playeveryware.com",
+    "dependencies": {
+        "com.unity.modules.jsonserialize": "1.0.0"
+    },
     "keywords": [
         "EOS", "Epic", "Epic Online Service"
     ],


### PR DESCRIPTION
The current version requires `JsonUtility` in `EOSManager`, so I added it as a package dependency.

FYI: https://docs.unity3d.com/ScriptReference/UnityEngine.JSONSerializeModule.html