### PR TITLE
Fix stuck on 2nd playthrough issue with second load.

### DIFF
--- a/Runtime/Core/EOSManager.cs
+++ b/Runtime/Core/EOSManager.cs
@@ -618,10 +618,7 @@ namespace PlayEveryWare.EpicOnlineServices
                     var secondTryResult = InitializePlatformInterface(loadedEOSConfig);
                     UnityEngine.Debug.LogWarning($"EOSManager::Init: InitializePlatformInterface: initResult = {secondTryResult}");
 
-                    if (secondTryResult != Result.Success)
-#endif
-#if (UNITY_EDITOR_OSX || UNITY_EDITOR_LINUX)
-                    if (secondTryResult != Result.AlreadyConfigured)
+                    if (secondTryResult != Result.Success && secondTryResult != Result.AlreadyConfigured)
 #endif
                     {
                         throw new System.Exception("Epic Online Services didn't init correctly: " + initResult);

--- a/Runtime/Core/EOSManager.cs
+++ b/Runtime/Core/EOSManager.cs
@@ -618,7 +618,7 @@ namespace PlayEveryWare.EpicOnlineServices
                     var secondTryResult = InitializePlatformInterface(loadedEOSConfig);
                     UnityEngine.Debug.LogWarning($"EOSManager::Init: InitializePlatformInterface: initResult = {secondTryResult}");
 
-                     if (secondTryResult != Result.Success)
+                    if (secondTryResult != Result.Success)
 #endif
 #if (UNITY_EDITOR_OSX || UNITY_EDITOR_LINUX)
                     if (secondTryResult != Result.AlreadyConfigured)

--- a/Runtime/Core/EOSManager.cs
+++ b/Runtime/Core/EOSManager.cs
@@ -618,7 +618,10 @@ namespace PlayEveryWare.EpicOnlineServices
                     var secondTryResult = InitializePlatformInterface(loadedEOSConfig);
                     UnityEngine.Debug.LogWarning($"EOSManager::Init: InitializePlatformInterface: initResult = {secondTryResult}");
 
-                    if (secondTryResult != Result.Success && secondTryResult != Result.AlreadyConfigured)
+                     if (secondTryResult != Result.Success)
+#endif
+#if (UNITY_EDITOR_OSX || UNITY_EDITOR_LINUX)
+                    if (secondTryResult != Result.AlreadyConfigured)
 #endif
                     {
                         throw new System.Exception("Epic Online Services didn't init correctly: " + initResult);

--- a/Runtime/Core/EOSManager_DynamicLoading.cs
+++ b/Runtime/Core/EOSManager_DynamicLoading.cs
@@ -333,12 +333,10 @@ namespace PlayEveryWare.EpicOnlineServices
                 do
                 {
                     existingHandle = SystemDynamicLibrary.GetHandleForModule(EOSBinaryName);
-                    if (existingHandle != IntPtr.Zero)
-                    {
-                        GC.WaitForPendingFinalizers();
-                        if (SystemDynamicLibrary.UnloadLibraryInEditor(existingHandle))
-                            break;
-                    }
+                    var dllHandle = new DLLHandle(existingHandle);
+                    // dllHandle.ReleaseHandle(); // it's protected, let's use reflection
+					var releaseHandleMethod = dllHandle.GetType().GetMethod("ReleaseHandle", BindingFlags.NonPublic | BindingFlags.Instance);
+					releaseHandleMethod.Invoke(dllHandle, null);
                     timeout--;
                 } while (IntPtr.Zero != existingHandle && timeout > 0);
 

--- a/Runtime/Core/EOSManager_DynamicLoading.cs
+++ b/Runtime/Core/EOSManager_DynamicLoading.cs
@@ -335,8 +335,8 @@ namespace PlayEveryWare.EpicOnlineServices
                     existingHandle = SystemDynamicLibrary.GetHandleForModule(EOSBinaryName);
                     var dllHandle = new DLLHandle(existingHandle);
                     // dllHandle.ReleaseHandle(); // it's protected, let's use reflection
-					var releaseHandleMethod = dllHandle.GetType().GetMethod("ReleaseHandle", BindingFlags.NonPublic | BindingFlags.Instance);
-					releaseHandleMethod.Invoke(dllHandle, null);
+                    var releaseHandleMethod = dllHandle.GetType().GetMethod("ReleaseHandle", BindingFlags.NonPublic | BindingFlags.Instance);
+                    releaseHandleMethod.Invoke(dllHandle, null);
                     timeout--;
                 } while (IntPtr.Zero != existingHandle && timeout > 0);
 

--- a/Runtime/Core/EOSManager_DynamicLoading.cs
+++ b/Runtime/Core/EOSManager_DynamicLoading.cs
@@ -336,7 +336,8 @@ namespace PlayEveryWare.EpicOnlineServices
                     if (existingHandle != IntPtr.Zero)
                     {
                         GC.WaitForPendingFinalizers();
-                        SystemDynamicLibrary.UnloadLibraryInEditor(existingHandle);
+                        if (SystemDynamicLibrary.UnloadLibraryInEditor(existingHandle))
+                            break;
                     }
                     timeout--;
                 } while (IntPtr.Zero != existingHandle && timeout > 0);

--- a/Runtime/Core/EOSManager_DynamicLoading.cs
+++ b/Runtime/Core/EOSManager_DynamicLoading.cs
@@ -333,10 +333,14 @@ namespace PlayEveryWare.EpicOnlineServices
                 do
                 {
                     existingHandle = SystemDynamicLibrary.GetHandleForModule(EOSBinaryName);
-                    var dllHandle = new DLLHandle(existingHandle);
-                    // dllHandle.ReleaseHandle(); // it's protected, let's use reflection
-                    var releaseHandleMethod = dllHandle.GetType().GetMethod("ReleaseHandle", BindingFlags.NonPublic | BindingFlags.Instance);
-                    releaseHandleMethod.Invoke(dllHandle, null);
+                    if (existingHandle != IntPtr.Zero)
+                    {
+                        GC.WaitForPendingFinalizers();
+                        var dllHandle = new DLLHandle(existingHandle);
+                        // dllHandle.ReleaseHandle(); // it's protected, let's use reflection
+                        var releaseHandleMethod = dllHandle.GetType().GetMethod("ReleaseHandle", BindingFlags.NonPublic | BindingFlags.Instance);
+                        releaseHandleMethod.Invoke(dllHandle, null);
+                    }
                     timeout--;
                 } while (IntPtr.Zero != existingHandle && timeout > 0);
 

--- a/Runtime/Linux/EOSManager_Linux.cs
+++ b/Runtime/Linux/EOSManager_Linux.cs
@@ -47,7 +47,8 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Epic.OnlineServices.IntegratedPlatform;
 
-#if !UNITY_EDITOR_WIN && (UNITY_STANDALONE_LINUX || UNITY_EDITOR_LINUX)
+//#if !UNITY_EDITOR_WIN && (UNITY_STANDALONE_LINUX || UNITY_EDITOR_LINUX)
+#if UNITY_STANDALONE_LINUX
 
 #if !UNITY_EDITOR_LINUX
 [assembly: AlwaysLinkAssembly]


### PR DESCRIPTION
# Issue
First playthrough works fine, but when you hit play again in Unity, the code get's stuck on `EOSManager_DynamicLoading.cs`.

![image](https://github.com/PlayEveryWare/eos_plugin_for_unity_upm/assets/1261843/a8ec0652-c752-4dca-a760-80ac596ef83e)

``` cs
//-------------------------------------------------------------------------
            // At the moment this only works on Windows.
            static private void ForceUnloadEOSLibrary()
            {
#if EOS_DYNAMIC_BINDINGS
                Epic.OnlineServices.Bindings.Unhook();
#endif

#if UNITY_EDITOR
                IntPtr existingHandle;
                int timeout = 50;
                do
                {
                    existingHandle = SystemDynamicLibrary.GetHandleForModule(EOSBinaryName);
                    if (existingHandle != IntPtr.Zero)
                    {
                        GC.WaitForPendingFinalizers();
                        SystemDynamicLibrary.UnloadLibraryInEditor(existingHandle);
                    }
                    timeout--;
                } while (IntPtr.Zero != existingHandle && timeout > 0);

                if (IntPtr.Zero != existingHandle)
                {
                    UnityEngine.Debug.LogWarning("Free Library { " + EOSBinaryName + " }:Timeout");
                }
#endif
            }
```

It specifically gets stuck on `SystemDynamicLibrary.UnloadLibraryInEditor(existingHandle);`.

My guess is it unloads it once successfully (@timeout = 50), and then because I guess it's simultaneously trying to load and unload it again (@timeout = 49), it gets deadlocked. 

# Solution

I think it is best once it unloads once successfully, break out this loop using this code:

```cs
if (SystemDynamicLibrary.UnloadLibraryInEditor(existingHandle)) 
    break;
```
This solution works on my initial tests... feel free to test on your side and accept this commit if you like. Thanks for this great plugin! 😄  
